### PR TITLE
session idの生成方法を変更

### DIFF
--- a/backend/lib/crypto/crypto.go
+++ b/backend/lib/crypto/crypto.go
@@ -1,17 +1,16 @@
 package crypto
 
 import (
+	"crypto/rand"
 	"encoding/base64"
-
-	"github.com/google/uuid"
+	"io"
 )
-
-// SecureRandomBase64 returns a random uuid string encoded by base64
-func SecureRandomBase64() string {
-	return base64.StdEncoding.EncodeToString(uuid.New().NodeID())
-}
 
 // LongSecureRandomBase64 returns twice length secure random string
 func LongSecureRandomBase64() string {
-	return SecureRandomBase64() + SecureRandomBase64()
+	b := make([]byte, 64)
+	if _, err := io.ReadFull(rand.Reader, b); err != nil {
+		return ""
+	}
+	return base64.URLEncoding.EncodeToString(b)
 }


### PR DESCRIPTION
## Why

暗号論的擬似乱数生成器を使うべき