### PR TITLE
use javascript redirect for avoiding universal link

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,8 +2,8 @@ name: Deploy
 
 on:
   push:
-    branches:
-      - master
+    #    branches:
+    # - master
     paths-ignore:
     - 'frontend/**'
     - 'ogp_functions/**'

--- a/frontend/src/components/ButtonTwitterLogin.tsx
+++ b/frontend/src/components/ButtonTwitterLogin.tsx
@@ -15,9 +15,6 @@ const TwitterButton = styled(ButtonBase)`
 export const ButtonTwitterLogin = () => {
   return (
     <TwitterButton
-      href={
-        'https://twitter.com/i/oauth2/authorize?client_id=aaaa&code_challenge=asdfasdf&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost.local%3A8080%2Fcallback&response_type=code&scope=tweet.read+users.read&state=asdfasdf'
-      }
       onClick={() => {
         if (isProd()) {
           window.gtag('event', 'login', {
@@ -26,6 +23,8 @@ export const ButtonTwitterLogin = () => {
             value: 1,
           })
         }
+        window.location.href =
+          'https://twitter.com/i/oauth2/authorize?client_id=aaaa&code_challenge=asdfasdf&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost.local%3A8080%2Fcallback&response_type=code&scope=tweet.read+users.read&state=asdfasdf'
       }}
     >
       <FontAwesomeIcon icon={faTwitter} style={{ paddingRight: '0.5rem' }} />

--- a/frontend/src/components/ButtonTwitterLogin.tsx
+++ b/frontend/src/components/ButtonTwitterLogin.tsx
@@ -15,7 +15,9 @@ const TwitterButton = styled(ButtonBase)`
 export const ButtonTwitterLogin = () => {
   return (
     <TwitterButton
-      href={getLoginUrl()}
+      href={
+        'https://twitter.com/i/oauth2/authorize?client_id=aaaa&code_challenge=asdfasdf&code_challenge_method=S256&redirect_uri=http%3A%2F%2Flocalhost.local%3A8080%2Fcallback&response_type=code&scope=tweet.read+users.read&state=asdfasdf'
+      }
       onClick={() => {
         if (isProd()) {
           window.gtag('event', 'login', {


### PR DESCRIPTION
iOSのアプリ内ブラウザでログインをしようとした場合、Locationヘッダーでリダイレクトすると、Twitterアプリが開いた後にデフフォルトのブラウザが表示されてしまう。
その場合、UAが異なることになりStateが一致しないのでエラーになってしまう。
原因はユニバーサルリンクの機能でTwitterアプリが開いてしまうことなので、ユニバーサルリンクが無効なJSによるリダイレクトを行うことで、同一UAを担保する