### PR TITLE
Use PORT env for Cloud Run

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -5,6 +5,10 @@ import (
 	"os"
 )
 
+func ReadPort() string {
+	return os.Getenv("PORT")
+}
+
 func ReadCloudFunctionsURL() string {
 	return os.Getenv("CLOUD_FUNCTIONS_URL")
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -51,8 +51,13 @@ func main() {
 		return
 	}
 
+	port := config.ReadPort()
+	if port == "" {
+		port = "8080"
+	}
+
 	srv := &http.Server{
-		Addr:    ":8080",
+		Addr:    ":" + port,
 		Handler: router,
 	}
 


### PR DESCRIPTION
> コンテナは、リクエストが送信されるポートで 0.0.0.0 のリクエストをリッスンする必要があります。デフォルトでリクエストは 8080 に送信されますが、選択したポートにリクエストを送信するように Cloud Run を構成することもできます。Cloud Run は、PORT 環境変数をコンテナに追加します。Cloud Run コンテナ インスタンス内では、リクエスト送信先ポートが PORT 環境変数の値に常に反映されます。デフォルトは 8080 です。

https://cloud.google.com/run/docs/container-contract